### PR TITLE
Update docusign.md - Correct spelling of DocuSign

### DIFF
--- a/docs/modeling/connectors/ootb/docusign.md
+++ b/docs/modeling/connectors/ootb/docusign.md
@@ -1,50 +1,50 @@
 ---
-Title: Docusign connector
+Title: DocuSign connector
 ---
 
-# Docusign connector
-The Docusign connector is used to send documents via email to be digitally signed. The process flow waits for a document to be signed before continuing with the process. The signed document
+# DocuSign connector
+The DocuSign connector is used to send documents via email to be digitally signed. The process flow waits for a document to be signed before continuing with the process. The signed document
 is saved to the Alfresco Content Services repository folder that corresponds to the process instance ID that called the connector in the following format:
 
 ```bash
 <application-name> Site / Document Library / <process-instance-id> / <service-task-id> / <signed-document>
 ``` 
 
-**Important**: The Docusign connector requires a licensed version of Alfresco Content Services (ACS) deployed to interact with. It also requires a [Docusign](https://www.docusign.com/) account to handle document signing. 
+**Important**: The DocuSign connector requires a licensed version of Alfresco Content Services (ACS) deployed to interact with. It also requires a [DocuSign](https://www.docusign.com/) account to handle document signing. 
 
-The Docusign connector is graphically represented by the Docusign logo under the OOTB Connectors menu whilst modeling a process.
+The DocuSign connector is graphically represented by the DocuSign logo under the OOTB Connectors menu whilst modeling a process.
 
-The `implementation` value of the Docusign connector in a service task would be similar to the following:
+The `implementation` value of the DocuSign connector in a service task would be similar to the following:
 
 ```xml
 <bpmn2:serviceTask id="ServiceTask_1jas8cr" implementation="docusignConnector.SIGNDOCUMENT" />
 ```
 
-## Docusign configuration
-The Docusign connector uses the Docusign REST API. An application needs to be set up and authorized to utilize this functionality in the connector. The following steps outline this process:
+## DocuSign configuration
+The DocuSign connector uses the DocuSign REST API. An application needs to be set up and authorized to utilize this functionality in the connector. The following steps outline this process:
 
-1. Sign into your Docusign account. 
+1. Sign into your DocuSign account. 
 2. [Configure an application for JWT authentication](https://developers.docusign.com/esign-rest-api/guides/authentication/oauth2-jsonwebtoken) including the prerequisites required to setup an RSA key. 
 3. [Grant consent to the application](https://developers.docusign.com/esign-rest-api/guides/authentication/obtaining-consent). 
 
 ## Connector variables
 Environment variables that are specific to a connector need to be specified during deployment. They are entered as connector variables and used as environment variables for the connector when it is deployed. 
 
-The following are the properties that need to be set for the Docusign connector: 
+The following are the properties that need to be set for the DocuSign connector: 
 
 | Variable | Description | 
 | -------- | ----------- | 
-| `DOCUSIGN_APILOCATION` | The URL of the Docusign REST API to use | 
-| `DOCUSIGN_ACCOUNT_ID` | The Docusign account that the application is registered to | 
+| `DOCUSIGN_APILOCATION` | The URL of the DocuSign REST API to use | 
+| `DOCUSIGN_ACCOUNT_ID` | The DocuSign account that the application is registered to | 
 | `DOCUSIGN_CLIENT_ID` | The application integration key | 
-| `DOCUSIGN_IMPERSONATED_USER_ID` | The GUID of the Docusign user that the application impersonates  | 
-| `DOCUSIGN_AUTH_SERVER` | The URL of the Docusign authorization server | 
+| `DOCUSIGN_IMPERSONATED_USER_ID` | The GUID of the DocuSign user that the application impersonates  | 
+| `DOCUSIGN_AUTH_SERVER` | The URL of the DocuSign authorization server | 
 | `DOCUSIGN_JWT_LIFETIME` | The expiration time of the JWT expressed in seconds | 
-| `DOCUSIGN_RSA_KEY` | The private RSA key for the Docusign application | 
+| `DOCUSIGN_RSA_KEY` | The private RSA key for the DocuSign application | 
 | `ALFRESCO_CONTENT_REPO_BASE_URL` | The base URL of the Content Services deployment |
 
 ## Input parameters 
-The following are the parameters that can be passed to the Docusign connector as input parameters using the `SIGNDOCUMENT` action:
+The following are the parameters that can be passed to the DocuSign connector as input parameters using the `SIGNDOCUMENT` action:
 
 | Parameter | Description | Type | Required? |
 | --------  | ----------- | ---- | --------- |
@@ -67,7 +67,7 @@ The following are the parameters that can be passed to the Docusign connector as
 `*` One of these parameters is required.   
 
 ## Output parameter
-The following is the parameter that is returned to the process by the Docusign connector as an output parameter using the `SIGNDOCUMENT` action:
+The following is the parameter that is returned to the process by the DocuSign connector as an output parameter using the `SIGNDOCUMENT` action:
 
 | Parameter | Description | Type |
 | --------  | ----------- | ---- |


### PR DESCRIPTION
The 's' in DocuSign should be and this PR changed the lower case 's' to an upper case 'S'.