### PR TITLE
AAE-8650 fix swagger ui url

### DIFF
--- a/docs/apis/README.md
+++ b/docs/apis/README.md
@@ -8,14 +8,14 @@ The REST APIs for Activiti Enterprise are accessed differently depending on whet
 ## Platform endpoints
 The OpenAPI specifications for platform endpoints are as follows:
 
-* Modeling service: `gateway.{domain-name}/modeling-service/swagger-ui.html`
-* Deployment service: `gateway.{domain-name}/deployment-service/swagger-ui.html`
+* Modeling service: `gateway.{domain-name}/modeling-service/swagger-ui/index.html`
+* Deployment service: `gateway.{domain-name}/deployment-service/swagger-ui/index.html`
 
 ## Application endpoints
 The OpenAPI specifications for application endpoints require the `{application-name}` element in the URL as demonstrated in the following:
 
-* Application runtime bundle: `gateway.{domain-name}/{application-name}/rb/swagger-ui.html`
-* Application query service: `gateway.{domain-name}/{application-name}/query/swagger-ui.html`
+* Application runtime bundle: `gateway.{domain-name}/{application-name}/rb/swagger-ui/index.html`
+* Application query service: `gateway.{domain-name}/{application-name}/query/swagger-ui/index.html`
 
 ### GraphQL
 The query service can also use [GraphQL](https://graphql.org/learn/) to expand on querying. It can be accessed at the following URL: 


### PR DESCRIPTION
The swagger-ui url changed from /swagger-ui.html to /swagger-ui/index.html after migration from Springfox to Springdoc. This should be reflected in the documentation.